### PR TITLE
chore: Fix image sizes to improve LH Score

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -37,74 +37,72 @@ export default function ProductCard({
   return (
     <div
       id={`product-card-${productID}`}
-      class="w-full p-2 group relative mb-5"
+      class="w-full p-2 mb-5"
     >
-      <div class="h-full z-10">
-        <a href={url}>
-          {img && img.url && (
-            <Picture>
-              <Source
-                media="(max-width: 639px)"
-                src={img.url}
-                width={234}
-                height={351}
-              />
-              <Source
-                media="(min-width: 640px)"
-                src={img.url}
-                width={312}
-                height={468}
-              />
-              <Image
-                class="w-full max-w-full h-auto"
-                src={img.url}
-                alt={img.alternateName}
-                width={312}
-                height={468}
-                loading="lazy"
-                decoding="async"
-              />
-            </Picture>
-          )}
-          <div class="mt-3">
-            {name && (
-              <div
-                class="block text-sm overflow-hidden whitespace-nowrap uppercase mb-3"
-                style={{ textOverflow: "ellipsis" }}
-                href={url}
-              >
-                {name.replace(/(.*)(\-).*$/, "$1$2")}
-              </div>
-            )}
-            <div class="text-xs flex justify-start gap-2 mb-1">
-              {listPrice && (
-                <span class="text-gray-400 line-through">
-                  R$ {listPrice.price.toFixed(2)}
-                </span>
-              )}
-              {price && (
-                <span class="font-bold">
-                  R$ {typeof price === "number" ? price.toFixed(2) : price}
-                </span>
-              )}
-            </div>
-            {installment && price && (
-              <div class="text-xs font-bold text-gray-500">
-                ou {installmentToString(installment, price)}
-              </div>
-            )}
-          </div>
-        </a>
-        {seller && (
-          <div class="mt-2">
-            <AddToCart
-              class="w-full text-white text-xs uppercase py-2 cursor-pointer"
-              skuId={productID}
-              sellerId={seller}
+      <a href={url}>
+        {img && img.url && (
+          <Picture>
+            <Source
+              media="(max-width: 639px)"
+              src={img.url}
+              width={234}
+              height={351}
             />
-          </div>
+            <Source
+              media="(min-width: 640px)"
+              src={img.url}
+              width={406}
+              height={608}
+            />
+            <Image
+              class="w-full max-w-full h-auto"
+              src={img.url}
+              alt={img.alternateName}
+              width={322}
+              height={483}
+              loading="lazy"
+              decoding="async"
+            />
+          </Picture>
         )}
-      </div>
+        <div class="mt-3">
+          {name && (
+            <div
+              class="block text-sm overflow-hidden whitespace-nowrap uppercase mb-3"
+              style={{ textOverflow: "ellipsis" }}
+              href={url}
+            >
+              {name.replace(/(.*)(\-).*$/, "$1$2")}
+            </div>
+          )}
+          <div class="text-xs flex justify-start gap-2 mb-1">
+            {listPrice && (
+              <span class="text-gray-400 line-through">
+                R$ {listPrice.price.toFixed(2)}
+              </span>
+            )}
+            {price && (
+              <span class="font-bold">
+                R$ {typeof price === "number" ? price.toFixed(2) : price}
+              </span>
+            )}
+          </div>
+          {installment && price && (
+            <div class="text-xs font-bold text-gray-500">
+              ou {installmentToString(installment, price)}
+            </div>
+          )}
+        </div>
+      </a>
+      {seller && (
+        <div class="mt-2">
+          <AddToCart
+            class="w-full text-white text-xs uppercase py-2 cursor-pointer"
+            skuId={productID}
+            sellerId={seller}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -5,6 +5,7 @@ import {
   bestInstallment,
   installmentToString,
 } from "../sections/ProductDetails.tsx";
+import { Picture, Source } from "$live/std/ui/components/Picture.tsx";
 
 interface Image {
   src: string;
@@ -41,16 +42,29 @@ export default function ProductCard({
       <div class="h-full z-10">
         <a href={url}>
           {img && img.url && (
-            <Image
-              class="w-full max-w-full h-auto"
-              src={img.url}
-              alt={img.alternateName}
-              width={326}
-              height={489}
-              sizes="(max-width: 640px) 40vw, 20vw"
-              loading="lazy"
-              decoding="async"
-            />
+            <Picture>
+              <Source
+                media="(max-width: 639px)"
+                src={img.url}
+                width={234}
+                height={351}
+              />
+              <Source
+                media="(min-width: 640px)"
+                src={img.url}
+                width={312}
+                height={468}
+              />
+              <Image
+                class="w-full max-w-full h-auto"
+                src={img.url}
+                alt={img.alternateName}
+                width={312}
+                height={468}
+                loading="lazy"
+                decoding="async"
+              />
+            </Picture>
           )}
           <div class="mt-3">
             {name && (

--- a/sections/Banner.tsx
+++ b/sections/Banner.tsx
@@ -1,5 +1,6 @@
 import { Image as LiveImage } from "$live/std/ui/types/Image.ts";
 import Image from "$live/std/ui/components/Image.tsx";
+import { Picture, Source } from "$live/std/ui/components/Picture.tsx";
 
 export type Props = {
   imgSrc: { mobile: LiveImage; desktop: LiveImage };
@@ -17,24 +18,31 @@ export default function Banner(
   return (
     <section class="w-full mb-8">
       <div class="relative">
-        <picture class="inset-0">
-          <source
+        <Picture class="inset-0" preload>
+          <Source
             media="(max-width: 767px)"
-            srcset={imgSrc.mobile}
-          />
-          <source
-            media="(min-width: 768px)"
-            srcset={imgSrc.desktop}
-          />
-          <Image
-            class="object-cover pb-5 w-full"
-            sizes="(max-width: 640px) 75vw, 50vw"
             src={imgSrc.mobile}
+            width={436}
+            height={377}
+            fetchPriority="high"
+          />
+          <Source
+            media="(min-width: 768px)"
+            src={imgSrc.desktop}
+            width={1920}
+            height={726}
+            fetchPriority="high"
+          />
+          <img
+            class="object-cover pb-5 w-full"
+            src={imgSrc.mobile}
+            sizes="(max-width: 640px) 75vw, 50vw"
             alt={alt}
             width={300}
             height={300}
+            loading="eager"
           />
-        </picture>
+        </Picture>
 
         <div class="absolute inset-0 md:flex md:flex-col md:items-center md:justify-center text-[#4d5b31] m-[4vh] md:m-auto md:text-[#f2e9d8] md:w-[28vw]">
           <a

--- a/sections/Banner.tsx
+++ b/sections/Banner.tsx
@@ -1,5 +1,4 @@
 import { Image as LiveImage } from "$live/std/ui/types/Image.ts";
-import Image from "$live/std/ui/components/Image.tsx";
 import { Picture, Source } from "$live/std/ui/components/Picture.tsx";
 
 export type Props = {

--- a/sections/ProductShelf.tsx
+++ b/sections/ProductShelf.tsx
@@ -15,7 +15,7 @@ export default function ProductShelf({
   return (
     <section class="max-w-[1400px] w-full p-2 md:p-0 mx-auto">
       {title && <h2 class="text-center mb-8 text-lg md:text-2xl">{title}</h2>}
-      <div class="grid grid-cols-2 md:grid-cols-4 md:gap-2">
+      <div class="grid grid-cols-2 md:grid-cols-4 md:gap-4">
         {products?.map((product, index) => {
           return <ProductCard key={index} {...product} />;
         })}


### PR DESCRIPTION
This PR improves banner image and improve ProductCard Image, to get a better page performance.

The banner image, used above the fold was the LCP and taking 6s to be rendered. To fix this, the Banner uses a picture with 2 sources, one for mobile, other for desktop, both images are prefetched/preloaded. Also, the Picture component uses de CDN to compress the image that decrease the size making the time to load the image lower.

The second problem was related to productcard images, that was fetching directly from VTEX image services, now is using the img service from Image component and with properly dimensions. Also, the image is loading lazy with deconding async.

The results below is using: [PSI Sample Tes](https://github.com/igorbrasileiro/psi-sample-test) running 30 times with mobile strategy
**Before:**
Page result - https://deco-sites-fashion-1zdbbt3nmypg.deno.dev/?pageId=2399
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0.02 | 0.00 | [0.02, 0.02] |
| First Contentful Paint (FCP) | 1832.08 | 0.00 | [1832.08, 1832.09] |
| Largest Contentful Paint (LCP) | 6282.08 | 4991.96 | [4495.73, 8068.44] |
| Time to Interactive (TTI) | 2058.42 | 0.78 | [2058.14, 2058.70] |
| Total Blocking Time (TBT) | 39.50 | 112.50 | [-0.76, 79.76] |
| Performance score | 0.747 | 0.000022 | [0.746659, 0.746675] |
| JavaScript Execution Time | 743.74 | 174.22 | [681.40, 806.09] |
| Speed Index | 3900.75 | 16901.73 | [-2147.45, 9948.96] |

**After:**
Page result - https://deco-sites-fashion-gm74ky42x720.deno.dev/?pageId=2399
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0.00 | 0.00 | [0.00, 0.00] |
| First Contentful Paint (FCP) | 1837.73 | 0.92 | [1837.40, 1838.06] |
| Largest Contentful Paint (LCP) | 2027.73 | 4273.44 | [498.50, 3556.96] |
| Time to Interactive (TTI) | 2165.49 | 21710.60 | [-5603.55, 9934.53] |
| Total Blocking Time (TBT) | 196.86 | 9943.45 | [-3361.36, 3755.08] |
| Performance score | 0.911 | 0.001252 | [0.910885, 0.911781] |
| JavaScript Execution Time | 1009.97 | 21536.22 | [-6696.67, 8716.61] |
| Speed Index | 4553.47 | 502241.85 | [-175171.47, 184278.40] |