### PR TITLE
feat: use flex instead of grid on shelf

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -32,7 +32,7 @@ export default function ProductCard({
   return (
     <div
       id={`product-card-${productID}`}
-      class="w-full p-2 mb-5"
+      class="w-full p-2 mb-5 min-w-[230px] max-w-[320px]"
     >
       <a href={url}>
         {img && img.url && (

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -32,7 +32,7 @@ export default function ProductCard({
   return (
     <div
       id={`product-card-${productID}`}
-      class="w-full p-2 mb-5 min-w-[230px] max-w-[320px]"
+      class="w-full p-2 mb-5"
     >
       <a href={url}>
         {img && img.url && (

--- a/sections/Carousel.tsx
+++ b/sections/Carousel.tsx
@@ -30,11 +30,11 @@ function Carousel({ images = [], preload = false }: Props) {
   return (
     <div
       id={id}
-      class="mb-8 relative"
+      class="mb-8 relative w-full overflow-hidden"
     >
       <ul
         data-slider-content
-        class="flex flex-nowrap overflow-auto transition"
+        class="flex flex-nowrap transition"
         style={{ width: `calc(${images.length}*100vw)` }}
       >
         {images.map(({ desktop, mobile, href, alt }, index) => {

--- a/sections/ProductShelf.tsx
+++ b/sections/ProductShelf.tsx
@@ -13,11 +13,22 @@ export default function ProductShelf({
   products,
 }: Props) {
   return (
-    <div class="max-w-[1400px] w-full p-2 md:p-0 mx-auto">
-      {title && <h2 class="text-center mb-8 text-lg md:text-2xl">{title}</h2>}
-      <ul class="flex flex-nowrap overflow-auto w-full justify-between">
+    <div class="max-w-[1400px] w-full p-2 flex flex-col items-center">
+      {title && <h2 class="mb-8 text-lg md:text-2xl">{title}</h2>}
+      <ul
+        class="flex flex-nowrap overflow-x-auto max-w-full gap-2"
+        // TODO: change this to class-based styling once ported to tailwind 3.0
+        style={{
+          "scroll-snap-type": "x mandatory",
+          "scroll-behavior": "smooth",
+          "-webkit-overflow-scrolling": "touch",
+        }}
+      >
         {products?.map((product, index) => (
-          <li class="min-w-[220px] max-w-[250px] sm:min-w-[260px] sm:max-w-[280px]">
+          <li
+            class="min-w-[220px] max-w-[250px] sm:min-w-[250px] sm:max-w-[280px]"
+            style={{ "scroll-snap-align": "center" }}
+          >
             <ProductCard key={index} {...product} />
           </li>
         ))}

--- a/sections/ProductShelf.tsx
+++ b/sections/ProductShelf.tsx
@@ -17,7 +17,7 @@ export default function ProductShelf({
       {title && <h2 class="text-center mb-8 text-lg md:text-2xl">{title}</h2>}
       <ul class="flex flex-nowrap overflow-auto w-full justify-between">
         {products?.map((product, index) => (
-          <li>
+          <li class="min-w-[230px] max-w-[320px]">
             <ProductCard key={index} {...product} />
           </li>
         ))}

--- a/sections/ProductShelf.tsx
+++ b/sections/ProductShelf.tsx
@@ -13,13 +13,15 @@ export default function ProductShelf({
   products,
 }: Props) {
   return (
-    <section class="max-w-[1400px] w-full p-2 md:p-0 mx-auto">
+    <div class="max-w-[1400px] w-full p-2 md:p-0 mx-auto">
       {title && <h2 class="text-center mb-8 text-lg md:text-2xl">{title}</h2>}
-      <div class="grid grid-cols-2 md:grid-cols-4 md:gap-4">
-        {products?.map((product, index) => {
-          return <ProductCard key={index} {...product} />;
-        })}
-      </div>
-    </section>
+      <ul class="flex flex-nowrap overflow-auto w-full justify-between">
+        {products?.map((product, index) => (
+          <li>
+            <ProductCard key={index} {...product} />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/sections/ProductShelf.tsx
+++ b/sections/ProductShelf.tsx
@@ -17,7 +17,7 @@ export default function ProductShelf({
       {title && <h2 class="text-center mb-8 text-lg md:text-2xl">{title}</h2>}
       <ul class="flex flex-nowrap overflow-auto w-full justify-between">
         {products?.map((product, index) => (
-          <li class="min-w-[230px] max-w-[320px]">
+          <li class="min-w-[220px] max-w-[250px] sm:min-w-[260px] sm:max-w-[280px]">
             <ProductCard key={index} {...product} />
           </li>
         ))}


### PR DESCRIPTION
Use flex instead of grid on shelf.

Before/after
<div style="display: flex">
<img width="300" src="https://user-images.githubusercontent.com/1753396/218844390-445cf294-8d7b-46d3-8214-4bbf23ca0746.gif" />
<img width="300" src="https://user-images.githubusercontent.com/1753396/218844321-8567c912-84b4-4606-9dfc-6cbbd808261c.gif" />
</div>
