### PR TITLE
feat: Add Suggestions to Header

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -2,7 +2,7 @@ import Modals from "$store/islands/HeaderModals.tsx";
 import type { Image } from "deco-sites/std/components/types.ts";
 import type { EditableProps as SearchbarProps } from "$store/components/search/Searchbar.tsx";
 import type { LoaderReturnType } from "$live/types.ts";
-import type { Product } from "deco-sites/std/commerce/types.ts";
+import type { Product, Suggestion } from "deco-sites/std/commerce/types.ts";
 
 import Alert from "./Alert.tsx";
 import Navbar from "./Navbar.tsx";
@@ -40,9 +40,16 @@ export interface Props {
    * @description Product suggestions displayed on search
    */
   products?: LoaderReturnType<Product[]>;
+
+  /**
+   * @title Enable Top Search terms
+   */
+  suggestions?: LoaderReturnType<Suggestion>;
 }
 
-function Header({ alerts, searchbar, products, navItems = [] }: Props) {
+function Header(
+  { alerts, searchbar, products, navItems = [], suggestions }: Props,
+) {
   return (
     <header class={`h-[${headerHeight}]`}>
       <div class="bg-default fixed w-full z-50">
@@ -52,7 +59,7 @@ function Header({ alerts, searchbar, products, navItems = [] }: Props) {
 
       <Modals
         menu={{ items: navItems }}
-        searchbar={{ ...searchbar, products }}
+        searchbar={{ ...searchbar, products, suggestions }}
       />
     </header>
   );

--- a/components/search/Searchbar.tsx
+++ b/components/search/Searchbar.tsx
@@ -13,7 +13,7 @@ import Text from "$store/components/ui/Text.tsx";
 import Button from "$store/components/ui/Button.tsx";
 import ProductCard from "$store/components/product/ProductCard.tsx";
 import Slider from "$store/components/ui/Slider.tsx";
-import type { Product } from "deco-sites/std/commerce/types.ts";
+import type { Product, Suggestion } from "deco-sites/std/commerce/types.ts";
 
 // Editable props
 export interface EditableProps {
@@ -47,13 +47,8 @@ export type Props = EditableProps & {
    * @description Product suggestions displayed on searchs
    */
   products?: Product[];
+  suggestions?: Suggestion;
 };
-
-const terms = [
-  "Vestido",
-  "Polo",
-  "Saia",
-];
 
 function Searchbar({
   placeholder = "What are you looking for?",
@@ -61,6 +56,7 @@ function Searchbar({
   name = "q",
   query,
   products,
+  suggestions: { searches } = {},
 }: Props) {
   return (
     <>
@@ -92,28 +88,30 @@ function Searchbar({
         </form>
       </div>
       <div class="flex flex-col divide-y divide-default">
-        <div class="flex flex-col gap-6 px-4 py-6">
-          <Text variant="heading-3">Termos mais buscados</Text>
-          <ul class="flex flex-col gap-6">
-            {terms.map((term) => (
-              <li>
-                <a href={`/s?q=${term}`} class="flex gap-4 items-center">
-                  <Text variant="body">
-                    <Icon
-                      id="MagnifyingGlass"
-                      width={20}
-                      height={20}
-                      strokeWidth={0.01}
-                    />
-                  </Text>
-                  <Text variant="body">
-                    {term}
-                  </Text>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {searches && (
+          <div class="flex flex-col gap-6 px-4 py-6">
+            <Text variant="heading-3">Termos mais buscados</Text>
+            <ul class="flex flex-col gap-6">
+              {searches.map(({ term }) => (
+                <li>
+                  <a href={`/s?q=${term}`} class="flex gap-4 items-center">
+                    <Text variant="body">
+                      <Icon
+                        id="MagnifyingGlass"
+                        width={20}
+                        height={20}
+                        strokeWidth={0.01}
+                      />
+                    </Text>
+                    <Text variant="body">
+                      {term}
+                    </Text>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         {products && (
           <div class="flex flex-col gap-6 py-6">
             <Text class="px-4" variant="heading-3">Produtos sugeridos</Text>

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -49,6 +49,7 @@ import * as $$$$12 from "deco-sites/std/functions/vtexLegacyProductListingPage.t
 import * as $$$$13 from "deco-sites/std/functions/vtexProductDetailsPage.ts";
 import * as $$$$14 from "deco-sites/std/functions/vtexProductList.ts";
 import * as $$$$15 from "deco-sites/std/functions/vtexProductListingPage.ts";
+import * as $$$$16 from "deco-sites/std/functions/vtexSuggestions.ts";
 
 const manifest: DecoManifest = {
   routes: {
@@ -102,6 +103,7 @@ const manifest: DecoManifest = {
     "deco-sites/std/functions/vtexProductDetailsPage.ts": $$$$13,
     "deco-sites/std/functions/vtexProductList.ts": $$$$14,
     "deco-sites/std/functions/vtexProductListingPage.ts": $$$$15,
+    "deco-sites/std/functions/vtexSuggestions.ts": $$$$16,
   },
   schemas: {
     "./sections/Carousel.tsx": {
@@ -687,6 +689,12 @@ const manifest: DecoManifest = {
             "type": "string",
             "title": "Product suggestions",
             "description": "Product suggestions displayed on search",
+          },
+          "suggestions": {
+            "$id": "ed6dd98378c4000f0975a28f1d78921b8e165be8",
+            "format": "live-function",
+            "type": "string",
+            "title": "Enable Top Search terms",
           },
         },
         "required": [
@@ -1589,6 +1597,33 @@ const manifest: DecoManifest = {
         "properties": {
           "data": {
             "$id": "05ecb684cf4ee00e98171fdc45227df637e4804e",
+          },
+        },
+        "additionalProperties": true,
+      },
+    },
+    "deco-sites/std/functions/vtexSuggestions.ts": {
+      "inputSchema": {
+        "title": "Vtex Suggestions",
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": [
+              "number",
+              "null",
+            ],
+            "title": "Count",
+            "description": "limit the number of searches",
+            "default": "4",
+          },
+        },
+        "required": [],
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$id": "ed6dd98378c4000f0975a28f1d78921b8e165be8",
           },
         },
         "additionalProperties": true,

--- a/import_map.json
+++ b/import_map.json
@@ -2,7 +2,7 @@
   "imports": {
     "$store/": "./",
     "$live/": "https://denopkg.com/deco-cx/live@0.8.1/",
-    "deco-sites/std/": "https://denopkg.com/deco-sites/std@0.0.5/",
+    "deco-sites/std/": "https://denopkg.com/deco-sites/std@0.0.6/",
     "partytown/": "https://deno.land/x/partytown@0.2.1/",
     "inspect_vscode/": "https://deno.land/x/inspect_vscode@0.1.2/",
     "$fresh/": "https://deno.land/x/fresh@1.1.3/",


### PR DESCRIPTION
This PR uses the new Suggestion from https://github.com/deco-sites/std/pull/4 in the header suggestions top searches section.

To test just open a preview with this queryString. `?pageId=3406` [example](https://deco-sites-fashion-7ze5p3m4hcpg.deno.dev/?pageId=3406)