### PR TITLE
fix: modal mobile

### DIFF
--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -60,12 +60,12 @@ const Modal = ({
     <dialog
       {...props}
       ref={ref}
-      class={`bg-transparent p-0 m-0 max-w-full sm:max-w-lg w-full max-h-screen h-screen backdrop ${variant}`}
+      class={`bg-transparent p-0 m-0 max-w-full sm:max-w-lg w-full max-h-screen min-h-full h-full backdrop ${variant}`}
       onClick={(e) =>
         (e.target as HTMLDialogElement).tagName === "DIALOG" && onClose?.()}
     >
-      <section class="pt-6 h-full bg-default flex flex-col">
-        <header class="flex px-4 justify-between items-center pb-6 border-b-1 border-default">
+      <section class="h-full bg-default flex flex-col">
+        <header class="flex px-4 justify-between items-center py-6 border-b-1 border-default">
           <h1>
             <Text variant="heading-2">{title}</Text>
           </h1>

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -73,7 +73,7 @@ const Modal = ({
             <Icon id="XMark" width={20} height={20} strokeWidth={2} />
           </Button>
         </header>
-        <div class="pt-6 overflow-y-auto h-full flex flex-col">
+        <div class="pt-6 overflow-y-auto flex-grow flex flex-col">
           {loading === "lazy" ? lazy.value && children : children}
         </div>
       </section>


### PR DESCRIPTION
Interestingly, 100vh is not what you think. It is the actual device's height, toolbar included. This means that if you install baidoo's toolbar 100vh will also take that into account and the website will break. The right value is 100% 👀. More info at: https://medium.com/developer-rants/what-if-height-100vh-is-bigger-than-your-screen-7f39c62ac170