### PR TITLE
fix: sku selector

### DIFF
--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -20,16 +20,20 @@ function Sizes(product: Product) {
 
   return (
     <ul class="flex justify-center items-center gap-2">
-      {options.map(([url, value]) => (
-        <a href={url}>
-          <Avatar
-            class="bg-default"
-            variant="abbreviation"
-            content={value}
-            disabled={url === product.url}
-          />
-        </a>
-      ))}
+      {options.map(([value, urls]) => {
+        const url = urls.find((url) => url === product.url) || urls[0];
+
+        return (
+          <a href={url}>
+            <Avatar
+              class="bg-default"
+              variant="abbreviation"
+              content={value}
+              disabled={url === product.url}
+            />
+          </a>
+        );
+      })}
     </ul>
   );
 }

--- a/components/product/ProductVariantSelector.tsx
+++ b/components/product/ProductVariantSelector.tsx
@@ -17,18 +17,22 @@ function VariantSelector({ product }: Props) {
         <li class="flex flex-col gap-2">
           <Text variant="caption">{name}</Text>
           <ul class="flex flex-row gap-2">
-            {Object.entries(possibilities[name]).map(([url, value]) => (
-              <li>
-                <a href={url}>
-                  <Avatar
-                    // deno-lint-ignore no-explicit-any
-                    content={value as any}
-                    disabled={url === currentUrl}
-                    variant={name === "COR" ? "color" : "abbreviation"}
-                  />
-                </a>
-              </li>
-            ))}
+            {Object.entries(possibilities[name]).map(([value, urls]) => {
+              const url = urls.find((url) => url === currentUrl) || urls[0];
+
+              return (
+                <li>
+                  <a href={url}>
+                    <Avatar
+                      // deno-lint-ignore no-explicit-any
+                      content={value as any}
+                      disabled={url === currentUrl}
+                      variant={name === "COR" ? "color" : "abbreviation"}
+                    />
+                  </a>
+                </li>
+              );
+            })}
           </ul>
         </li>
       ))}

--- a/sdk/useVariantPossiblities.ts
+++ b/sdk/useVariantPossiblities.ts
@@ -11,15 +11,20 @@ export const useVariantPossibilities = ({ isVariantOf }: Product) => {
   const possibilities = allProperties.reduce((acc, { property, url }) => {
     const { name = "", value = "" } = property;
 
+    if (!acc[name]) {
+      acc[name] = {};
+    }
+
+    if (!acc[name][value]) {
+      acc[name][value] = [];
+    }
+
     if (url) {
-      acc[name] = {
-        ...acc[name],
-        [url]: value,
-      };
+      acc[name][value].push(url);
     }
 
     return acc;
-  }, {} as Record<string, Record<string, string>>);
+  }, {} as Record<string, Record<string, string[]>>);
 
   return possibilities;
 };


### PR DESCRIPTION
## What is this contribution about?
Fix sku selector when the same variation is present across multiple skus. I've seen this wrong behavior in multiple accounts during our hackathon

## How to test it?
Using some accounts on VTEX, we get the following before/after behavior, while maintaining the old fashion behavior

<img width="153" alt="image" src="https://user-images.githubusercontent.com/1753396/227501939-8c6e726e-5860-43cc-ad85-9966034da74d.png">
<img width="188" alt="image" src="https://user-images.githubusercontent.com/1753396/227501625-c31ff5e9-6682-469d-a4cb-1e05682b4ea2.png">

Also, note that the selected variation is always hrefing the current sku. 

