### PR TITLE
feat: Linktree

### DIFF
--- a/components/ui/LinkTree.tsx
+++ b/components/ui/LinkTree.tsx
@@ -1,0 +1,76 @@
+import { Image as LiveImage } from "deco-sites/std/components/types.ts";
+import Image from "deco-sites/std/components/Image.tsx";
+import Icon from "$store/components/ui/Icon.tsx";
+import Text from "$store/components/ui/Text.tsx";
+
+export interface Link {
+  label: string;
+  href: string;
+}
+
+export interface Social {
+  label: "Instagram" | "Facebook";
+  href: string;
+}
+
+export interface Props {
+  title?: string;
+  description?: string;
+  links?: Link[];
+  bgImage?: LiveImage;
+  avatar?: LiveImage;
+  social?: Social[];
+}
+
+function LinkTree({
+  bgImage,
+  avatar,
+  title = "",
+  description = "",
+  links,
+  social,
+}: Props) {
+  return (
+    <div
+      class="flex flex-col justify-start items-center gap-10 bg-interactive p-10 h-screen overflow-y-hidden"
+      style={bgImage ? { background: `url(${bgImage})` } : undefined}
+    >
+      <header class="flex flex-col justify-center items-center gap-4">
+        <div class="rounded-full w-min bg-default p-4">
+          {avatar
+            ? <Image src={avatar} width={150} height={150} />
+            : <Icon id="Logo" size={150} />}
+        </div>
+        <Text tone="default-inverse" variant="heading-3">{title}</Text>
+        <Text tone="default-inverse" variant="body">{description}</Text>
+      </header>
+      <main class="w-full max-w-[80%] sm:max-w-[50%]">
+        <ul class="flex flex-col justify-center items-center gap-4">
+          {links?.map((link) => (
+            <li class="w-full">
+              <a
+                href={link.href}
+                class="text-interactive-inverse text-caption rounded-3xl text-center w-full flex justify-center items-center min-h-[36px] hover:(bg-interactive-inverse text-interactive) border border-default"
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </main>
+      <footer>
+        <ul class="flex flex-row gap-4">
+          {social?.map((link) => (
+            <li>
+              <a href={link.href} class="text-interactive-inverse block rounded">
+                <Icon id={link.label} size={36} strokeWidth={0.8} />
+              </a>
+            </li>
+          ))}
+        </ul>
+      </footer>
+    </div>
+  );
+}
+
+export default LinkTree;

--- a/components/ui/LinkTree.tsx
+++ b/components/ui/LinkTree.tsx
@@ -62,7 +62,10 @@ function LinkTree({
         <ul class="flex flex-row gap-4">
           {social?.map((link) => (
             <li>
-              <a href={link.href} class="text-interactive-inverse block rounded">
+              <a
+                href={link.href}
+                class="text-interactive-inverse block rounded"
+              >
                 <Icon id={link.label} size={36} strokeWidth={0.8} />
               </a>
             </li>

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -24,18 +24,19 @@ import * as $$$4 from "./sections/Features.tsx";
 import * as $$$5 from "./sections/Footer.tsx";
 import * as $$$6 from "./sections/Header.tsx";
 import * as $$$7 from "./sections/Highlights.tsx";
-import * as $$$8 from "./sections/ProductDetails.tsx";
-import * as $$$9 from "./sections/ProductGallery.tsx";
-import * as $$$10 from "./sections/ProductShelf.tsx";
-import * as $$$11 from "./sections/SearchControls.tsx";
-import * as $$$12 from "./sections/WhatsApp.tsx";
-import * as $$$13 from "deco-sites/std/sections/SEO.tsx";
-import * as $$$14 from "deco-sites/std/sections/SEOPDP.tsx";
-import * as $$$15 from "deco-sites/std/sections/SEOPLP.tsx";
-import * as $$$16 from "deco-sites/std/sections/configOCC.global.tsx";
-import * as $$$17 from "deco-sites/std/sections/configShopify.global.tsx";
-import * as $$$18 from "deco-sites/std/sections/configVTEX.global.tsx";
-import * as $$$19 from "deco-sites/std/sections/configYourViews.tsx";
+import * as $$$8 from "./sections/LinkTree.tsx";
+import * as $$$9 from "./sections/ProductDetails.tsx";
+import * as $$$10 from "./sections/ProductGallery.tsx";
+import * as $$$11 from "./sections/ProductShelf.tsx";
+import * as $$$12 from "./sections/SearchControls.tsx";
+import * as $$$13 from "./sections/WhatsApp.tsx";
+import * as $$$14 from "deco-sites/std/sections/SEO.tsx";
+import * as $$$15 from "deco-sites/std/sections/SEOPDP.tsx";
+import * as $$$16 from "deco-sites/std/sections/SEOPLP.tsx";
+import * as $$$17 from "deco-sites/std/sections/configOCC.global.tsx";
+import * as $$$18 from "deco-sites/std/sections/configShopify.global.tsx";
+import * as $$$19 from "deco-sites/std/sections/configVTEX.global.tsx";
+import * as $$$20 from "deco-sites/std/sections/configYourViews.tsx";
 import * as $$$$0 from "$live/functions/EffectSelectPage.ts";
 import * as $$$$1 from "$live/functions/MatchDate.ts";
 import * as $$$$2 from "$live/functions/MatchEnvironment.ts";
@@ -81,18 +82,19 @@ const manifest: DecoManifest = {
     "./sections/Footer.tsx": $$$5,
     "./sections/Header.tsx": $$$6,
     "./sections/Highlights.tsx": $$$7,
-    "./sections/ProductDetails.tsx": $$$8,
-    "./sections/ProductGallery.tsx": $$$9,
-    "./sections/ProductShelf.tsx": $$$10,
-    "./sections/SearchControls.tsx": $$$11,
-    "./sections/WhatsApp.tsx": $$$12,
-    "deco-sites/std/sections/SEO.tsx": $$$13,
-    "deco-sites/std/sections/SEOPDP.tsx": $$$14,
-    "deco-sites/std/sections/SEOPLP.tsx": $$$15,
-    "deco-sites/std/sections/configOCC.global.tsx": $$$16,
-    "deco-sites/std/sections/configShopify.global.tsx": $$$17,
-    "deco-sites/std/sections/configVTEX.global.tsx": $$$18,
-    "deco-sites/std/sections/configYourViews.tsx": $$$19,
+    "./sections/LinkTree.tsx": $$$8,
+    "./sections/ProductDetails.tsx": $$$9,
+    "./sections/ProductGallery.tsx": $$$10,
+    "./sections/ProductShelf.tsx": $$$11,
+    "./sections/SearchControls.tsx": $$$12,
+    "./sections/WhatsApp.tsx": $$$13,
+    "deco-sites/std/sections/SEO.tsx": $$$14,
+    "deco-sites/std/sections/SEOPDP.tsx": $$$15,
+    "deco-sites/std/sections/SEOPLP.tsx": $$$16,
+    "deco-sites/std/sections/configOCC.global.tsx": $$$17,
+    "deco-sites/std/sections/configShopify.global.tsx": $$$18,
+    "deco-sites/std/sections/configVTEX.global.tsx": $$$19,
+    "deco-sites/std/sections/configYourViews.tsx": $$$20,
   },
   functions: {
     "$live/functions/EffectSelectPage.ts": $$$$0,
@@ -895,6 +897,94 @@ const manifest: DecoManifest = {
         "required": [
           "title",
         ],
+      },
+      "outputSchema": null,
+    },
+    "./sections/LinkTree.tsx": {
+      "inputSchema": {
+        "title": " Link Tree",
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": [
+              "string",
+              "null",
+            ],
+            "title": "Title",
+          },
+          "description": {
+            "type": [
+              "string",
+              "null",
+            ],
+            "title": "Description",
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "title": "Link",
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "title": "Label",
+                },
+                "href": {
+                  "type": "string",
+                  "title": "Href",
+                },
+              },
+              "required": [
+                "label",
+                "href",
+              ],
+            },
+            "title": "Links",
+          },
+          "bgImage": {
+            "format": "image-uri",
+            "type": "string",
+            "title": "Bg Image",
+          },
+          "avatar": {
+            "format": "image-uri",
+            "type": "string",
+            "title": "Avatar",
+          },
+          "social": {
+            "type": "array",
+            "items": {
+              "title": "Social",
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "Instagram",
+                    },
+                    {
+                      "type": "string",
+                      "const": "Facebook",
+                    },
+                  ],
+                  "title": "Label",
+                },
+                "href": {
+                  "type": "string",
+                  "title": "Href",
+                },
+              },
+              "required": [
+                "label",
+                "href",
+              ],
+            },
+            "title": "Social",
+          },
+        },
+        "required": [],
       },
       "outputSchema": null,
     },

--- a/sections/LinkTree.tsx
+++ b/sections/LinkTree.tsx
@@ -1,3 +1,3 @@
 export { default } from "$store/components/ui/LinkTree.tsx";
-export type { Props, Link, Social } from "$store/components/ui/LinkTree.tsx"
+export type { Link, Props, Social } from "$store/components/ui/LinkTree.tsx";
 export type { Image as LiveImage } from "deco-sites/std/components/types.ts";

--- a/sections/LinkTree.tsx
+++ b/sections/LinkTree.tsx
@@ -1,0 +1,3 @@
+export { default } from "$store/components/ui/LinkTree.tsx";
+export type { Props, Link, Social } from "$store/components/ui/LinkTree.tsx"
+export type { Image as LiveImage } from "deco-sites/std/components/types.ts";


### PR DESCRIPTION
## What is this contribution about?
This PR adds a new LinkTree section such that business users may create a landing page with their linktree on their website domain.

## How to test it?
Open workbench and check the section. Note that this section should be used in standalone mode

## Extra info


<img width="1508" alt="image" src="https://user-images.githubusercontent.com/1753396/227515673-9824a95b-bcf7-40de-b5be-fd1850267ef2.png">


<img width="370" alt="image" src="https://user-images.githubusercontent.com/1753396/227515499-91166d87-2bac-46df-b46c-a57e81ca93b5.png">
<img width="503" alt="image" src="https://user-images.githubusercontent.com/1753396/227515532-5dc95e7e-6311-4663-ba94-c20491476317.png">
