### PR TITLE
feat: Aside filters

### DIFF
--- a/components/search/Controls.tsx
+++ b/components/search/Controls.tsx
@@ -7,28 +7,23 @@ import Modal from "$store/components/ui/Modal.tsx";
 import Breadcrumb from "$store/components/ui/Breadcrumb.tsx";
 import { useSignal } from "@preact/signals";
 import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
-import type { LoaderReturnType } from "$live/types.ts";
 
-export interface Props {
-  page: LoaderReturnType<ProductListingPage | null>;
-}
+type Props = Pick<ProductListingPage, "filters" | "breadcrumb"> & {
+  displayFilter?: boolean;
+};
 
-function NotFound() {
-  return <div />;
-}
-
-function Controls({ page }: { page: ProductListingPage }) {
+function SearchControls({ filters, breadcrumb, displayFilter }: Props) {
   const open = useSignal(false);
-  const filters = page?.filters;
-  const breadcrumb = page?.breadcrumb;
 
   return (
-    <Container class="flex flex-col justify-between mb-4 md:mb-0 p-4 md:p-0 sm:gap-4 sm:flex-row sm:h-[53px] md:border-b-1">
+    <div class="flex flex-col justify-between mb-4 p-4 sm:(mb-0 p-0 gap-4 flex-row h-[53px] border-b-1)">
       <div class="flex flex-row items-center sm:p-0 mb-2">
         <Breadcrumb itemListElement={breadcrumb?.itemListElement} />
       </div>
-      <div class="flex flex-row sm:gap-4 items-center justify-between border-b-1 border-default md:border-none">
+
+      <div class="flex flex-row items-center justify-between border-b-1 border-default sm:(gap-4 border-none)">
         <Button
+          class={displayFilter ? '' : 'sm:hidden'}
           variant="tertiary"
           onClick={() => {
             open.value = true;
@@ -41,6 +36,7 @@ function Controls({ page }: { page: ProductListingPage }) {
       </div>
 
       <Modal
+        loading="lazy"
         title="Filtrar"
         mode="sidebar-right"
         open={open.value}
@@ -50,16 +46,8 @@ function Controls({ page }: { page: ProductListingPage }) {
       >
         <Filters filters={filters} />
       </Modal>
-    </Container>
+    </div>
   );
-}
-
-function SearchControls({ page }: Props) {
-  if (!page || !page.filters || page.filters.length === 0) {
-    return <NotFound />;
-  }
-
-  return <Controls page={page} />;
 }
 
 export default SearchControls;

--- a/components/search/Controls.tsx
+++ b/components/search/Controls.tsx
@@ -23,7 +23,7 @@ function SearchControls({ filters, breadcrumb, displayFilter }: Props) {
 
       <div class="flex flex-row items-center justify-between border-b-1 border-default sm:(gap-4 border-none)">
         <Button
-          class={displayFilter ? '' : 'sm:hidden'}
+          class={displayFilter ? "" : "sm:hidden"}
           variant="tertiary"
           onClick={() => {
             open.value = true;

--- a/components/search/Filters.tsx
+++ b/components/search/Filters.tsx
@@ -60,7 +60,7 @@ function FilterValues({ key, values }: FilterToggle) {
   );
 }
 
-export default function Filters({ filters }: Props) {
+function Filters({ filters }: Props) {
   return (
     <ul class="flex flex-col gap-6 p-4">
       {filters
@@ -74,3 +74,5 @@ export default function Filters({ filters }: Props) {
     </ul>
   );
 }
+
+export default Filters;

--- a/components/search/SearchResult.tsx
+++ b/components/search/SearchResult.tsx
@@ -1,13 +1,16 @@
+import Filters from "$store/components/search/Filters.tsx";
 import ProductCard from "$store/components/product/ProductCard.tsx";
 import Container from "$store/components/ui/Container.tsx";
 import Button from "$store/components/ui/Button.tsx";
 import Text from "$store/components/ui/Text.tsx";
 import Icon from "$store/components/ui/Icon.tsx";
+import SearchControls from "$store/islands/SearchControls.tsx";
 import type { LoaderReturnType } from "$live/types.ts";
 import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
 
 export interface Props {
   page: LoaderReturnType<ProductListingPage | null>;
+  variant?: "sidebar" | "drawer";
 }
 
 function NotFound() {
@@ -18,21 +21,41 @@ function NotFound() {
   );
 }
 
-function Gallery({ page }: { page: ProductListingPage }) {
+function Result({
+  page,
+  variant,
+}: { page: ProductListingPage; variant: Props["variant"] }) {
+  const { products, filters, breadcrumb, pageInfo } = page;
+
   return (
     <Container class="px-4 sm:py-10">
-      <div class="relative grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-10 items-center">
-        {page.products?.map((product, index) => (
-          <div class="w-full list-none">
+      <SearchControls
+        filters={filters}
+        breadcrumb={breadcrumb}
+        displayFilter={variant === "drawer"}
+      />
+
+      <div class="flex flex-row">
+        {variant === "sidebar" && (
+          <aside class="hidden sm:block w-min min-w-[250px] row-start-1 row-span-full col-start-1 col-span-1">
+            <Filters filters={filters} />
+          </aside>
+        )}
+        <div
+          class={`flex-grow grid grid-cols-2 gap-2 items-center sm:(grid-cols-${
+            variant === "sidebar" ? 3 : 4
+          } gap-10)`}
+        >
+          {products?.map((product, index) => (
             <ProductCard product={product} preload={index === 0} />
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
 
       <div class="flex flex-row items-center justify-center gap-2 my-4">
-        <a rel="prev" href={page.pageInfo.previousPage ?? "#"}>
+        <a rel="prev" href={pageInfo.previousPage ?? "#"}>
           <Button
-            disabled={!page.pageInfo.previousPage}
+            disabled={!pageInfo.previousPage}
             variant="icon"
             aria-label="previous page"
           >
@@ -40,11 +63,11 @@ function Gallery({ page }: { page: ProductListingPage }) {
           </Button>
         </a>
         <Text variant="caption">
-          {page.pageInfo.currentPage + 1}
+          {pageInfo.currentPage + 1}
         </Text>
-        <a rel="next" href={page.pageInfo.nextPage ?? "#"}>
+        <a rel="next" href={pageInfo.nextPage ?? "#"}>
           <Button
-            disabled={!page.pageInfo.nextPage}
+            disabled={!pageInfo.nextPage}
             variant="icon"
             aria-label="next page"
           >
@@ -56,12 +79,12 @@ function Gallery({ page }: { page: ProductListingPage }) {
   );
 }
 
-function ProductGallery({ page }: Props) {
+function SearchResult({ page, variant = "sidebar" }: Props) {
   if (!page) {
     return <NotFound />;
   }
 
-  return <Gallery page={page} />;
+  return <Result page={page} variant={variant} />;
 }
 
-export default ProductGallery;
+export default SearchResult;

--- a/components/search/SearchResult.tsx
+++ b/components/search/SearchResult.tsx
@@ -10,7 +10,7 @@ import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
 
 export interface Props {
   page: LoaderReturnType<ProductListingPage | null>;
-  variant?: "sidebar" | "drawer";
+  variant?: "aside" | "drawer";
 }
 
 function NotFound() {
@@ -36,14 +36,14 @@ function Result({
       />
 
       <div class="flex flex-row">
-        {variant === "sidebar" && (
+        {variant === "aside" && (
           <aside class="hidden sm:block w-min min-w-[250px] row-start-1 row-span-full col-start-1 col-span-1">
             <Filters filters={filters} />
           </aside>
         )}
         <div
           class={`flex-grow grid grid-cols-2 gap-2 items-center sm:(grid-cols-${
-            variant === "sidebar" ? 3 : 4
+            variant === "aside" ? 3 : 4
           } gap-10)`}
         >
           {products?.map((product, index) => (
@@ -79,7 +79,7 @@ function Result({
   );
 }
 
-function SearchResult({ page, variant = "sidebar" }: Props) {
+function SearchResult({ page, variant = "aside" }: Props) {
   if (!page) {
     return <NotFound />;
   }

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -27,18 +27,17 @@ import * as $$$6 from "./sections/Header.tsx";
 import * as $$$7 from "./sections/Highlights.tsx";
 import * as $$$8 from "./sections/LinkTree.tsx";
 import * as $$$9 from "./sections/ProductDetails.tsx";
-import * as $$$10 from "./sections/ProductGallery.tsx";
-import * as $$$11 from "./sections/ProductShelf.tsx";
-import * as $$$12 from "./sections/SearchControls.tsx";
-import * as $$$13 from "./sections/WhatsApp.tsx";
-import * as $$$14 from "deco-sites/std/sections/SEO.tsx";
-import * as $$$15 from "deco-sites/std/sections/SEOPDP.tsx";
-import * as $$$16 from "deco-sites/std/sections/SEOPLP.tsx";
-import * as $$$17 from "deco-sites/std/sections/configOCC.global.tsx";
-import * as $$$18 from "deco-sites/std/sections/configShopify.global.tsx";
-import * as $$$19 from "deco-sites/std/sections/configVNDA.global.tsx";
-import * as $$$20 from "deco-sites/std/sections/configVTEX.global.tsx";
-import * as $$$21 from "deco-sites/std/sections/configYourViews.tsx";
+import * as $$$10 from "./sections/ProductShelf.tsx";
+import * as $$$11 from "./sections/SearchResult.tsx";
+import * as $$$12 from "./sections/WhatsApp.tsx";
+import * as $$$13 from "deco-sites/std/sections/SEO.tsx";
+import * as $$$14 from "deco-sites/std/sections/SEOPDP.tsx";
+import * as $$$15 from "deco-sites/std/sections/SEOPLP.tsx";
+import * as $$$16 from "deco-sites/std/sections/configOCC.global.tsx";
+import * as $$$17 from "deco-sites/std/sections/configShopify.global.tsx";
+import * as $$$18 from "deco-sites/std/sections/configVNDA.global.tsx";
+import * as $$$19 from "deco-sites/std/sections/configVTEX.global.tsx";
+import * as $$$20 from "deco-sites/std/sections/configYourViews.tsx";
 import * as $$$$0 from "$live/functions/EffectSelectPage.ts";
 import * as $$$$1 from "$live/functions/MatchDate.ts";
 import * as $$$$2 from "$live/functions/MatchEnvironment.ts";
@@ -91,18 +90,17 @@ const manifest: DecoManifest = {
     "./sections/Highlights.tsx": $$$7,
     "./sections/LinkTree.tsx": $$$8,
     "./sections/ProductDetails.tsx": $$$9,
-    "./sections/ProductGallery.tsx": $$$10,
-    "./sections/ProductShelf.tsx": $$$11,
-    "./sections/SearchControls.tsx": $$$12,
-    "./sections/WhatsApp.tsx": $$$13,
-    "deco-sites/std/sections/SEO.tsx": $$$14,
-    "deco-sites/std/sections/SEOPDP.tsx": $$$15,
-    "deco-sites/std/sections/SEOPLP.tsx": $$$16,
-    "deco-sites/std/sections/configOCC.global.tsx": $$$17,
-    "deco-sites/std/sections/configShopify.global.tsx": $$$18,
-    "deco-sites/std/sections/configVNDA.global.tsx": $$$19,
-    "deco-sites/std/sections/configVTEX.global.tsx": $$$20,
-    "deco-sites/std/sections/configYourViews.tsx": $$$21,
+    "./sections/ProductShelf.tsx": $$$10,
+    "./sections/SearchResult.tsx": $$$11,
+    "./sections/WhatsApp.tsx": $$$12,
+    "deco-sites/std/sections/SEO.tsx": $$$13,
+    "deco-sites/std/sections/SEOPDP.tsx": $$$14,
+    "deco-sites/std/sections/SEOPLP.tsx": $$$15,
+    "deco-sites/std/sections/configOCC.global.tsx": $$$16,
+    "deco-sites/std/sections/configShopify.global.tsx": $$$17,
+    "deco-sites/std/sections/configVNDA.global.tsx": $$$18,
+    "deco-sites/std/sections/configVTEX.global.tsx": $$$19,
+    "deco-sites/std/sections/configYourViews.tsx": $$$20,
   },
   functions: {
     "$live/functions/EffectSelectPage.ts": $$$$0,
@@ -1046,24 +1044,6 @@ const manifest: DecoManifest = {
       },
       "outputSchema": null,
     },
-    "./sections/ProductGallery.tsx": {
-      "inputSchema": {
-        "title": " Product Gallery",
-        "type": "object",
-        "properties": {
-          "page": {
-            "$id": "93678a2f6c9ab06d039c9fcd9714055f1a81449f",
-            "format": "live-function",
-            "type": "string",
-            "title": "Page",
-          },
-        },
-        "required": [
-          "page",
-        ],
-      },
-      "outputSchema": null,
-    },
     "./sections/ProductShelf.tsx": {
       "inputSchema": {
         "title": " Product Shelf",
@@ -1094,9 +1074,9 @@ const manifest: DecoManifest = {
       },
       "outputSchema": null,
     },
-    "./sections/SearchControls.tsx": {
+    "./sections/SearchResult.tsx": {
       "inputSchema": {
-        "title": " Search Controls",
+        "title": " Search Result",
         "type": "object",
         "properties": {
           "page": {
@@ -1104,6 +1084,20 @@ const manifest: DecoManifest = {
             "format": "live-function",
             "type": "string",
             "title": "Page",
+          },
+          "variant": {
+            "type": "string",
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "sidebar",
+              },
+              {
+                "type": "string",
+                "const": "drawer",
+              },
+            ],
+            "title": "Variant",
           },
         },
         "required": [

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -1090,7 +1090,7 @@ const manifest: DecoManifest = {
             "anyOf": [
               {
                 "type": "string",
-                "const": "sidebar",
+                "const": "aside",
               },
               {
                 "type": "string",

--- a/sections/ProductGallery.tsx
+++ b/sections/ProductGallery.tsx
@@ -1,9 +1,0 @@
-import ProductGallery, {
-  Props,
-} from "$store/components/product/ProductGallery.tsx";
-
-function ProductGallerySection(props: Props) {
-  return <ProductGallery {...props} />;
-}
-
-export default ProductGallerySection;

--- a/sections/SearchControls.tsx
+++ b/sections/SearchControls.tsx
@@ -1,8 +1,0 @@
-import SearchControls from "$store/islands/SearchControls.tsx";
-import type { Props } from "$store/components/search/Controls.tsx";
-
-function SearchControlsSection(props: Props) {
-  return <SearchControls {...props} />;
-}
-
-export default SearchControlsSection;

--- a/sections/SearchResult.tsx
+++ b/sections/SearchResult.tsx
@@ -1,0 +1,7 @@
+import SearchResult, { Props } from "$store/components/search/SearchResult.tsx";
+
+function SearchResultSection(props: Props) {
+  return <SearchResult {...props} />;
+}
+
+export default SearchResultSection;


### PR DESCRIPTION
## What is this contribution about?
Closes #116 by adding a new option to Deco's editor: "aside" and "drawer". Aside means the filters will render aside, while drawer will fallback to the mobile-like behavior on desktop.
Also, this PR renames and merges both ProductGallery and SearchControls into a single SearchResult section. Alongside these changes, this PR adds the option to the business user to change the grid layout of the search result. 

## How to test it?
Open any category and check the right aside filter
