### PR TITLE
removing Props from sections/WishlistGallery

### DIFF
--- a/sections/WishlistGallery.tsx
+++ b/sections/WishlistGallery.tsx
@@ -1,2 +1,1 @@
 export { default } from "deco-sites/fashion/components/wishlist/WishlistGallery.tsx";
-export type { Props } from "deco-sites/fashion/components/wishlist/WishlistGallery.tsx";


### PR DESCRIPTION
## What is this contribution about?

While running `deno task check`, I got: 
```
deno task check                                                                                                                       [14:59:18]
Task check deno fmt && deno lint && deno check dev.ts main.ts
Checked 97 files
Checked 89 files
Check file:///Users/marjoripomarole/projects/deco/fashion/dev.ts
Check file:///Users/marjoripomarole/projects/deco/fashion/main.ts
error: TS2614 [ERROR]: Module '"file:///Users/marjoripomarole/projects/deco/fashion/components/wishlist/WishlistGallery.tsx"' has no exported member 'Props'. Did you mean to use 'import Props from "file:///Users/marjoripomarole/projects/deco/fashion/components/wishlist/WishlistGallery.tsx"' instead?
export type { Props } from "deco-sites/fashion/components/wishlist/WishlistGallery.tsx";
              ~~~~~
    at file:///Users/marjoripomarole/projects/deco/fashion/sections/WishlistGallery.tsx:2:15
```

Doesn't look like `sections/WishlistGallery.tsx` needs to export Props. So I am removing this line.

## How to test it?

After fix:
```
marjoripomarole➜projects/deco/fashion(wishlist-gallery✗)» deno task check                                                                                                                       [14:59:11]
Task check deno fmt && deno lint && deno check dev.ts main.ts
Checked 97 files
Checked 89 files
```
