### PR TITLE
poc: Preserving scroll

### DIFF
--- a/components/GlobalTags.tsx
+++ b/components/GlobalTags.tsx
@@ -27,7 +27,6 @@ function GlobalTags() {
 
       {/* Web Manifest */}
       <link rel="manifest" href={asset("/site.webmanifest")} />
-
       <script
         type="text/javascript"
         dangerouslySetInnerHTML={{

--- a/components/GlobalTags.tsx
+++ b/components/GlobalTags.tsx
@@ -27,6 +27,25 @@ function GlobalTags() {
 
       {/* Web Manifest */}
       <link rel="manifest" href={asset("/site.webmanifest")} />
+
+      <script
+        type="text/javascript"
+        dangerouslySetInnerHTML={{
+          __html: `
+        window.addEventListener('load', function() {
+          const STORAGE_SCROLL_KEY = 'deco-pages-scroll';
+          const top = sessionStorage.getItem(STORAGE_SCROLL_KEY)
+          if (top !== null) {
+            console.log('scrolling to ' + top);
+            document.documentElement.scrollTop = parseInt(top, 10);
+          }
+          window.addEventListener('beforeunload', () => {
+            sessionStorage.setItem(STORAGE_SCROLL_KEY, document.documentElement.scrollTop || document.body.scrollTop);
+          })
+      })
+        `,
+        }}
+      />
     </Head>
   );
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "deco-sites/fashion/": "./",
-    "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.2.8/",
+    "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.3.0/",
     "$live/": "https://denopkg.com/deco-cx/live@1.2.2/",
     "$fresh/": "https://deno.land/x/fresh@1.1.5/",
     "preact": "https://esm.sh/preact@10.13.2",


### PR DESCRIPTION
Copied from https://begin.com/blog/posts/2023-01-12-restoring-scroll-position-for-server-rendered-sites

I do not love scroll hijacking. Posting this so we can evaluate the trade-offs.

Possible problems with this solution:
- Setting scroll to a specific location in navigations we wanted to reset it (e.g: pagination)
- If the page has a layout shift because of JS, for instance, the time the scroll set happens might not have all the elements fully loaded.

I know that those seem fixable, but it certainly doesn't stop there.

Maybe we use it solely for product pages?

https://www.loom.com/share/93cb016f3a18481a8f9873d30e68a294