### PR TITLE
Extend product card props to search result

### DIFF
--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -8,6 +8,34 @@ import { mapProductToAnalyticsItem } from "deco-sites/std/commerce/utils/product
 import { SendEventOnClick } from "$store/sdk/analytics.tsx";
 import type { Product } from "deco-sites/std/commerce/types.ts";
 
+export interface Layout {
+  basics?: {
+    contentAlignment?: "Left" | "Center";
+    oldPriceSize?: "Small" | "Normal";
+    ctaText?: string;
+  };
+  elementsPositions?: {
+    skuSelector?: "Top" | "Bottom";
+    favoriteIcon?: "Top right" | "Top left";
+  };
+  hide?: {
+    productName?: boolean;
+    productDescription?: boolean;
+    allPrices?: boolean;
+    installments?: boolean;
+    skuSelector?: boolean;
+    cta?: boolean;
+  };
+  onMouseOver?: {
+    image?: "Change image" | "Zoom image";
+    card?: "None" | "Move up";
+    showFavoriteIcon?: boolean;
+    showSkuSelector?: boolean;
+    showCardShadow?: boolean;
+    showCta?: boolean;
+  };
+}
+
 interface Props {
   product: Product;
   /** Preload card image */
@@ -15,33 +43,7 @@ interface Props {
 
   /** @description used for analytics event */
   itemListName?: string;
-  layout?: {
-    basics?: {
-      contentAlignment?: "Left" | "Center";
-      oldPriceSize?: "Small" | "Normal";
-      ctaText?: string;
-    };
-    elementsPositions?: {
-      skuSelector?: "Top" | "Bottom";
-      favoriteIcon?: "Top right" | "Top left";
-    };
-    hide?: {
-      productName?: boolean;
-      productDescription?: boolean;
-      allPrices?: boolean;
-      installments?: boolean;
-      skuSelector?: boolean;
-      cta?: boolean;
-    };
-    onMouseOver?: {
-      image?: "Change image" | "Zoom image";
-      card?: "None" | "Move up";
-      showFavoriteIcon?: boolean;
-      showSkuSelector?: boolean;
-      showCardShadow?: boolean;
-      showCta?: boolean;
-    };
-  };
+  layout?: Layout;
 }
 
 const relative = (url: string) => {

--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -25,7 +25,7 @@ interface Props {
       skuSelector?: "Top" | "Bottom";
       favoriteIcon?: "Top right" | "Top left";
     };
-    hide: {
+    hide?: {
       productName?: boolean;
       productDescription?: boolean;
       allPrices?: boolean;
@@ -215,7 +215,7 @@ function ProductCard({ product, preload, itemListName, layout }: Props) {
         {(!l?.elementsPositions?.skuSelector ||
           l?.elementsPositions?.skuSelector === "Top") && (
           <>
-            {l?.hide.skuSelector ? "" : (
+            {l?.hide?.skuSelector ? "" : (
               <ul
                 class={`flex items-center gap-2 w-full ${
                   align === "center" ? "justify-center" : "justify-start"
@@ -227,18 +227,18 @@ function ProductCard({ product, preload, itemListName, layout }: Props) {
           </>
         )}
 
-        {l?.hide.productName && l?.hide.productDescription
+        {l?.hide?.productName && l?.hide?.productDescription
           ? ""
           : (
             <div class="flex flex-col gap-0">
-              {l?.hide.productName
+              {l?.hide?.productName
                 ? ""
                 : (
                   <h2 class="truncate text-base lg:text-lg text-base-content">
                     {name}
                   </h2>
                 )}
-              {l?.hide.productDescription
+              {l?.hide?.productDescription
                 ? ""
                 : (
                   <p class="truncate text-sm lg:text-sm text-neutral">
@@ -247,7 +247,7 @@ function ProductCard({ product, preload, itemListName, layout }: Props) {
                 )}
             </div>
           )}
-        {l?.hide.allPrices ? "" : (
+        {l?.hide?.allPrices ? "" : (
           <div class="flex flex-col gap-2">
             <div
               class={`flex flex-col gap-0 ${
@@ -267,7 +267,7 @@ function ProductCard({ product, preload, itemListName, layout }: Props) {
                 {formatPrice(price, offers!.priceCurrency!)}
               </div>
             </div>
-            {l?.hide.installments
+            {l?.hide?.installments
               ? ""
               : (
                 <div class="text-base-300 text-sm lg:text-base">
@@ -280,7 +280,7 @@ function ProductCard({ product, preload, itemListName, layout }: Props) {
         {/* SKU Selector */}
         {l?.elementsPositions?.skuSelector === "Bottom" && (
           <>
-            {l?.hide.skuSelector ? "" : (
+            {l?.hide?.skuSelector ? "" : (
               <ul
                 class={`flex items-center gap-2 w-full ${
                   align === "center" ? "justify-center" : "justify-start"
@@ -292,7 +292,7 @@ function ProductCard({ product, preload, itemListName, layout }: Props) {
           </>
         )}
 
-        {!l?.hide.cta
+        {!l?.hide?.cta
           ? (
             <div
               class={`flex-auto flex items-end ${

--- a/components/product/ProductGallery.tsx
+++ b/components/product/ProductGallery.tsx
@@ -1,6 +1,6 @@
 import { Product } from "deco-sites/std/commerce/types.ts";
 
-import ProductCard from "./ProductCard.tsx";
+import ProductCard, { Layout as cardLayout } from "$store/components/product/ProductCard.tsx";;
 
 export interface Columns {
   mobile?: number;
@@ -9,33 +9,7 @@ export interface Columns {
 
 export interface Props {
   products: Product[] | null;
-  layout?: {
-    basics?: {
-      contentAlignment?: "Left" | "Center";
-      oldPriceSize?: "Small" | "Normal";
-      ctaText?: string;
-    };
-    elementsPositions?: {
-      skuSelector?: "Top" | "Bottom";
-      favoriteIcon?: "Top right" | "Top left";
-    };
-    hide?: {
-      productName?: boolean;
-      productDescription?: boolean;
-      allPrices?: boolean;
-      installments?: boolean;
-      skuSelector?: boolean;
-      cta?: boolean;
-    };
-    onMouseOver?: {
-      image?: "Change image" | "Zoom image";
-      card?: "None" | "Move up";
-      showFavoriteIcon?: boolean;
-      showSkuSelector?: boolean;
-      showCardShadow?: boolean;
-      showCta?: boolean;
-    };
-  };
+  layout?: cardLayout;
 }
 
 function ProductGallery({ products, layout }: Props) {

--- a/components/product/ProductGallery.tsx
+++ b/components/product/ProductGallery.tsx
@@ -9,13 +9,40 @@ export interface Columns {
 
 export interface Props {
   products: Product[] | null;
+  layout?: {
+    basics?: {
+      contentAlignment?: "Left" | "Center";
+      oldPriceSize?: "Small" | "Normal";
+      ctaText?: string;
+    };
+    elementsPositions?: {
+      skuSelector?: "Top" | "Bottom";
+      favoriteIcon?: "Top right" | "Top left";
+    };
+    hide?: {
+      productName?: boolean;
+      productDescription?: boolean;
+      allPrices?: boolean;
+      installments?: boolean;
+      skuSelector?: boolean;
+      cta?: boolean;
+    };
+    onMouseOver?: {
+      image?: "Change image" | "Zoom image";
+      card?: "None" | "Move up";
+      showFavoriteIcon?: boolean;
+      showSkuSelector?: boolean;
+      showCardShadow?: boolean;
+      showCta?: boolean;
+    };
+  };
 }
 
-function ProductGallery({ products }: Props) {
+function ProductGallery({ products, layout }: Props) {
   return (
     <div class="grid grid-cols-2 gap-2 items-center sm:grid-cols-4 sm:gap-10">
       {products?.map((product, index) => (
-        <ProductCard product={product} preload={index === 0} />
+        <ProductCard product={product} preload={index === 0} layout={layout} />
       ))}
     </div>
   );

--- a/components/product/ProductShelf.tsx
+++ b/components/product/ProductShelf.tsx
@@ -28,7 +28,7 @@ export interface Props {
       skuSelector?: "Top" | "Bottom";
       favoriteIcon?: "Top right" | "Top left";
     };
-    hide: {
+    hide?: {
       productName?: boolean;
       productDescription?: boolean;
       allPrices?: boolean;

--- a/components/product/ProductShelf.tsx
+++ b/components/product/ProductShelf.tsx
@@ -1,4 +1,4 @@
-import ProductCard from "$store/components/product/ProductCard.tsx";
+import ProductCard, { Layout as cardLayout } from "$store/components/product/ProductCard.tsx";
 import SliderJS from "$store/islands/SliderJS.tsx";
 import Icon from "$store/components/ui/Icon.tsx";
 import Slider from "$store/components/ui/Slider.tsx";
@@ -18,33 +18,7 @@ export interface Props {
     headerAlignment?: "center" | "left";
     headerfontSize?: "Normal" | "Large";
   };
-  cardLayout?: {
-    basics?: {
-      contentAlignment?: "Left" | "Center";
-      oldPriceSize?: "Small" | "Normal";
-      ctaText?: string;
-    };
-    elementsPositions?: {
-      skuSelector?: "Top" | "Bottom";
-      favoriteIcon?: "Top right" | "Top left";
-    };
-    hide?: {
-      productName?: boolean;
-      productDescription?: boolean;
-      allPrices?: boolean;
-      installments?: boolean;
-      skuSelector?: boolean;
-      cta?: boolean;
-    };
-    onMouseOver?: {
-      image?: "Change image" | "Zoom image";
-      card?: "None" | "Move up";
-      showFavoriteIcon?: boolean;
-      showSkuSelector?: boolean;
-      showCardShadow?: boolean;
-      showCta?: boolean;
-    };
-  };
+  cardLayout?: cardLayout;
 }
 
 function ProductShelf({

--- a/components/search/SearchResult.tsx
+++ b/components/search/SearchResult.tsx
@@ -5,48 +5,25 @@ import { SendEventOnLoad } from "$store/sdk/analytics.tsx";
 import { mapProductToAnalyticsItem } from "deco-sites/std/commerce/utils/productToAnalyticsItem.ts";
 import { useOffer } from "$store/sdk/useOffer.ts";
 import ProductGallery, { Columns } from "../product/ProductGallery.tsx";
+import { Layout as cardLayout } from "$store/components/product/ProductCard.tsx";;
 import type { LoaderReturnType } from "$live/types.ts";
 import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
 
+export interface Layout {
+  /**
+   * @description Use drawer for mobile like behavior on desktop. Aside for rendering the filters alongside the products
+   */
+  variant?: "aside" | "drawer";
+  /**
+   * @description Number of products per line on grid
+   */
+  columns: Columns;
+}
+
 export interface Props {
   page: LoaderReturnType<ProductListingPage | null>;
-  layout?: {
-    /**
-     * @description Use drawer for mobile like behavior on desktop. Aside for rendering the filters alongside the products
-     */
-    variant?: "aside" | "drawer";
-    /**
-     * @description Number of products per line on grid
-     */
-    columns: Columns;
-  };
-  cardLayout?: {
-    basics?: {
-      contentAlignment?: "Left" | "Center";
-      oldPriceSize?: "Small" | "Normal";
-      ctaText?: string;
-    };
-    elementsPositions?: {
-      skuSelector?: "Top" | "Bottom";
-      favoriteIcon?: "Top right" | "Top left";
-    };
-    hide?: {
-      productName?: boolean;
-      productDescription?: boolean;
-      allPrices?: boolean;
-      installments?: boolean;
-      skuSelector?: boolean;
-      cta?: boolean;
-    };
-    onMouseOver?: {
-      image?: "Change image" | "Zoom image";
-      card?: "None" | "Move up";
-      showFavoriteIcon?: boolean;
-      showSkuSelector?: boolean;
-      showCardShadow?: boolean;
-      showCta?: boolean;
-    };
-  };
+  layout?: Layout;
+  cardLayout?: cardLayout;
 }
 
 function NotFound() {

--- a/components/search/SearchResult.tsx
+++ b/components/search/SearchResult.tsx
@@ -10,14 +10,43 @@ import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
 
 export interface Props {
   page: LoaderReturnType<ProductListingPage | null>;
-  /**
-   * @description Use drawer for mobile like behavior on desktop. Aside for rendering the filters alongside the products
-   */
-  variant?: "aside" | "drawer";
-  /**
-   * @description Number of products per line on grid
-   */
-  columns: Columns;
+  layout?: {
+    /**
+     * @description Use drawer for mobile like behavior on desktop. Aside for rendering the filters alongside the products
+     */
+    variant?: "aside" | "drawer";
+    /**
+     * @description Number of products per line on grid
+     */
+    columns: Columns;
+  };
+  cardLayout?: {
+    basics?: {
+      contentAlignment?: "Left" | "Center";
+      oldPriceSize?: "Small" | "Normal";
+      ctaText?: string;
+    };
+    elementsPositions?: {
+      skuSelector?: "Top" | "Bottom";
+      favoriteIcon?: "Top right" | "Top left";
+    };
+    hide?: {
+      productName?: boolean;
+      productDescription?: boolean;
+      allPrices?: boolean;
+      installments?: boolean;
+      skuSelector?: boolean;
+      cta?: boolean;
+    };
+    onMouseOver?: {
+      image?: "Change image" | "Zoom image";
+      card?: "None" | "Move up";
+      showFavoriteIcon?: boolean;
+      showSkuSelector?: boolean;
+      showCardShadow?: boolean;
+      showCta?: boolean;
+    };
+  };
 }
 
 function NotFound() {
@@ -30,7 +59,8 @@ function NotFound() {
 
 function Result({
   page,
-  variant,
+  layout,
+  cardLayout,
 }: Omit<Props, "page"> & { page: ProductListingPage }) {
   const { products, filters, breadcrumb, pageInfo, sortOptions } = page;
 
@@ -41,17 +71,17 @@ function Result({
           sortOptions={sortOptions}
           filters={filters}
           breadcrumb={breadcrumb}
-          displayFilter={variant === "drawer"}
+          displayFilter={layout?.variant === "drawer"}
         />
 
         <div class="flex flex-row">
-          {variant === "aside" && filters.length > 0 && (
+          {layout?.variant === "aside" && filters.length > 0 && (
             <aside class="hidden sm:block w-min min-w-[250px]">
               <Filters filters={filters} />
             </aside>
           )}
           <div class="flex-grow">
-            <ProductGallery products={products} />
+            <ProductGallery products={products} layout={cardLayout} />
           </div>
         </div>
 

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -10985,9 +10985,7 @@
               "title": "On Mouse Over"
             }
           },
-          "required": [
-            "hide"
-          ],
+          "required": [],
           "title": "Card Layout"
         }
       },
@@ -11024,32 +11022,246 @@
           "$ref": "#/definitions/ZGVjby1zaXRlcy9zdGQvY29tbWVyY2UvdHlwZXMudHM=@ProductListingPage|null",
           "title": "Page"
         },
-        "variant": {
-          "anyOf": [
-            {
+        "layout": {
+          "type": "object",
+          "properties": {
+            "variant": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "aside",
+                  "default": "aside"
+                },
+                {
+                  "type": "string",
+                  "const": "drawer",
+                  "default": "drawer"
+                }
+              ],
               "type": "string",
-              "const": "aside",
-              "default": "aside"
+              "title": "Variant"
             },
-            {
-              "type": "string",
-              "const": "drawer",
-              "default": "drawer"
+            "columns": {
+              "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0R2FsbGVyeS50c3g=@Columns",
+              "title": "Columns"
             }
+          },
+          "required": [
+            "columns"
           ],
-          "type": "string",
-          "description": "Use drawer for mobile like behavior on desktop. Aside for rendering the filters alongside the products",
-          "title": "Variant"
+          "title": "Layout"
         },
-        "columns": {
-          "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0R2FsbGVyeS50c3g=@Columns",
-          "description": "Number of products per line on grid",
-          "title": "Columns"
+        "cardLayout": {
+          "type": "object",
+          "properties": {
+            "basics": {
+              "type": "object",
+              "properties": {
+                "contentAlignment": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "Left",
+                      "default": "Left"
+                    },
+                    {
+                      "type": "string",
+                      "const": "Center",
+                      "default": "Center"
+                    }
+                  ],
+                  "type": "string",
+                  "title": "Content Alignment"
+                },
+                "oldPriceSize": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "Small",
+                      "default": "Small"
+                    },
+                    {
+                      "type": "string",
+                      "const": "Normal",
+                      "default": "Normal"
+                    }
+                  ],
+                  "type": "string",
+                  "title": "Old Price Size"
+                },
+                "ctaText": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "title": "Cta Text"
+                }
+              },
+              "required": [],
+              "title": "Basics"
+            },
+            "elementsPositions": {
+              "type": "object",
+              "properties": {
+                "skuSelector": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "Top",
+                      "default": "Top"
+                    },
+                    {
+                      "type": "string",
+                      "const": "Bottom",
+                      "default": "Bottom"
+                    }
+                  ],
+                  "type": "string",
+                  "title": "Sku Selector"
+                },
+                "favoriteIcon": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "Top right",
+                      "default": "Top right"
+                    },
+                    {
+                      "type": "string",
+                      "const": "Top left",
+                      "default": "Top left"
+                    }
+                  ],
+                  "type": "string",
+                  "title": "Favorite Icon"
+                }
+              },
+              "required": [],
+              "title": "Elements Positions"
+            },
+            "hide": {
+              "type": "object",
+              "properties": {
+                "productName": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Product Name"
+                },
+                "productDescription": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Product Description"
+                },
+                "allPrices": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "All Prices"
+                },
+                "installments": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Installments"
+                },
+                "skuSelector": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Sku Selector"
+                },
+                "cta": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Cta"
+                }
+              },
+              "required": [],
+              "title": "Hide"
+            },
+            "onMouseOver": {
+              "type": "object",
+              "properties": {
+                "image": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "Change image",
+                      "default": "Change image"
+                    },
+                    {
+                      "type": "string",
+                      "const": "Zoom image",
+                      "default": "Zoom image"
+                    }
+                  ],
+                  "type": "string",
+                  "title": "Image"
+                },
+                "card": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "None",
+                      "default": "None"
+                    },
+                    {
+                      "type": "string",
+                      "const": "Move up",
+                      "default": "Move up"
+                    }
+                  ],
+                  "type": "string",
+                  "title": "Card"
+                },
+                "showFavoriteIcon": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Show Favorite Icon"
+                },
+                "showSkuSelector": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Show Sku Selector"
+                },
+                "showCardShadow": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Show Card Shadow"
+                },
+                "showCta": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "title": "Show Cta"
+                }
+              },
+              "required": [],
+              "title": "On Mouse Over"
+            }
+          },
+          "required": [],
+          "title": "Card Layout"
         }
       },
       "required": [
-        "page",
-        "columns"
+        "page"
       ],
       "title": "deco-sites/fashion/components/search/SearchResult.tsx@Props"
     },

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -10720,6 +10720,214 @@
       ],
       "title": "deco-sites/fashion/components/product/ProductDetails.tsx@Props"
     },
+    "ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0Q2FyZC50c3g=@Layout": {
+      "type": "object",
+      "properties": {
+        "basics": {
+          "type": "object",
+          "properties": {
+            "contentAlignment": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "Left",
+                  "default": "Left"
+                },
+                {
+                  "type": "string",
+                  "const": "Center",
+                  "default": "Center"
+                }
+              ],
+              "type": "string",
+              "title": "Content Alignment"
+            },
+            "oldPriceSize": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "Small",
+                  "default": "Small"
+                },
+                {
+                  "type": "string",
+                  "const": "Normal",
+                  "default": "Normal"
+                }
+              ],
+              "type": "string",
+              "title": "Old Price Size"
+            },
+            "ctaText": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "title": "Cta Text"
+            }
+          },
+          "required": [],
+          "title": "Basics"
+        },
+        "elementsPositions": {
+          "type": "object",
+          "properties": {
+            "skuSelector": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "Top",
+                  "default": "Top"
+                },
+                {
+                  "type": "string",
+                  "const": "Bottom",
+                  "default": "Bottom"
+                }
+              ],
+              "type": "string",
+              "title": "Sku Selector"
+            },
+            "favoriteIcon": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "Top right",
+                  "default": "Top right"
+                },
+                {
+                  "type": "string",
+                  "const": "Top left",
+                  "default": "Top left"
+                }
+              ],
+              "type": "string",
+              "title": "Favorite Icon"
+            }
+          },
+          "required": [],
+          "title": "Elements Positions"
+        },
+        "hide": {
+          "type": "object",
+          "properties": {
+            "productName": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Product Name"
+            },
+            "productDescription": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Product Description"
+            },
+            "allPrices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "All Prices"
+            },
+            "installments": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Installments"
+            },
+            "skuSelector": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Sku Selector"
+            },
+            "cta": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Cta"
+            }
+          },
+          "required": [],
+          "title": "Hide"
+        },
+        "onMouseOver": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "Change image",
+                  "default": "Change image"
+                },
+                {
+                  "type": "string",
+                  "const": "Zoom image",
+                  "default": "Zoom image"
+                }
+              ],
+              "type": "string",
+              "title": "Image"
+            },
+            "card": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "None",
+                  "default": "None"
+                },
+                {
+                  "type": "string",
+                  "const": "Move up",
+                  "default": "Move up"
+                }
+              ],
+              "type": "string",
+              "title": "Card"
+            },
+            "showFavoriteIcon": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Show Favorite Icon"
+            },
+            "showSkuSelector": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Show Sku Selector"
+            },
+            "showCardShadow": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Show Card Shadow"
+            },
+            "showCta": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "title": "Show Cta"
+            }
+          },
+          "required": [],
+          "title": "On Mouse Over"
+        }
+      },
+      "required": [],
+      "title": "Layout"
+    },
     "ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0U2hlbGYudHN4@Props": {
       "type": "object",
       "properties": {
@@ -10781,211 +10989,7 @@
           "title": "Layout"
         },
         "cardLayout": {
-          "type": "object",
-          "properties": {
-            "basics": {
-              "type": "object",
-              "properties": {
-                "contentAlignment": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Left",
-                      "default": "Left"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Center",
-                      "default": "Center"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Content Alignment"
-                },
-                "oldPriceSize": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Small",
-                      "default": "Small"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Normal",
-                      "default": "Normal"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Old Price Size"
-                },
-                "ctaText": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "title": "Cta Text"
-                }
-              },
-              "required": [],
-              "title": "Basics"
-            },
-            "elementsPositions": {
-              "type": "object",
-              "properties": {
-                "skuSelector": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Top",
-                      "default": "Top"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Bottom",
-                      "default": "Bottom"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Sku Selector"
-                },
-                "favoriteIcon": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Top right",
-                      "default": "Top right"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Top left",
-                      "default": "Top left"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Favorite Icon"
-                }
-              },
-              "required": [],
-              "title": "Elements Positions"
-            },
-            "hide": {
-              "type": "object",
-              "properties": {
-                "productName": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Product Name"
-                },
-                "productDescription": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Product Description"
-                },
-                "allPrices": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "All Prices"
-                },
-                "installments": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Installments"
-                },
-                "skuSelector": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Sku Selector"
-                },
-                "cta": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Cta"
-                }
-              },
-              "required": [],
-              "title": "Hide"
-            },
-            "onMouseOver": {
-              "type": "object",
-              "properties": {
-                "image": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Change image",
-                      "default": "Change image"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Zoom image",
-                      "default": "Zoom image"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Image"
-                },
-                "card": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "None",
-                      "default": "None"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Move up",
-                      "default": "Move up"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Card"
-                },
-                "showFavoriteIcon": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Favorite Icon"
-                },
-                "showSkuSelector": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Sku Selector"
-                },
-                "showCardShadow": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Card Shadow"
-                },
-                "showCta": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Cta"
-                }
-              },
-              "required": [],
-              "title": "On Mouse Over"
-            }
-          },
-          "required": [],
+          "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0Q2FyZC50c3g=@Layout",
           "title": "Card Layout"
         }
       },
@@ -11015,6 +11019,37 @@
       "required": [],
       "title": "Columns"
     },
+    "ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvc2VhcmNoL1NlYXJjaFJlc3VsdC50c3g=@Layout": {
+      "type": "object",
+      "properties": {
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "aside",
+              "default": "aside"
+            },
+            {
+              "type": "string",
+              "const": "drawer",
+              "default": "drawer"
+            }
+          ],
+          "type": "string",
+          "description": "Use drawer for mobile like behavior on desktop. Aside for rendering the filters alongside the products",
+          "title": "Variant"
+        },
+        "columns": {
+          "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0R2FsbGVyeS50c3g=@Columns",
+          "description": "Number of products per line on grid",
+          "title": "Columns"
+        }
+      },
+      "required": [
+        "columns"
+      ],
+      "title": "Layout"
+    },
     "ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvc2VhcmNoL1NlYXJjaFJlc3VsdC50c3g=@Props": {
       "type": "object",
       "properties": {
@@ -11023,240 +11058,11 @@
           "title": "Page"
         },
         "layout": {
-          "type": "object",
-          "properties": {
-            "variant": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "const": "aside",
-                  "default": "aside"
-                },
-                {
-                  "type": "string",
-                  "const": "drawer",
-                  "default": "drawer"
-                }
-              ],
-              "type": "string",
-              "title": "Variant"
-            },
-            "columns": {
-              "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0R2FsbGVyeS50c3g=@Columns",
-              "title": "Columns"
-            }
-          },
-          "required": [
-            "columns"
-          ],
+          "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvc2VhcmNoL1NlYXJjaFJlc3VsdC50c3g=@Layout",
           "title": "Layout"
         },
         "cardLayout": {
-          "type": "object",
-          "properties": {
-            "basics": {
-              "type": "object",
-              "properties": {
-                "contentAlignment": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Left",
-                      "default": "Left"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Center",
-                      "default": "Center"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Content Alignment"
-                },
-                "oldPriceSize": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Small",
-                      "default": "Small"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Normal",
-                      "default": "Normal"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Old Price Size"
-                },
-                "ctaText": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "title": "Cta Text"
-                }
-              },
-              "required": [],
-              "title": "Basics"
-            },
-            "elementsPositions": {
-              "type": "object",
-              "properties": {
-                "skuSelector": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Top",
-                      "default": "Top"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Bottom",
-                      "default": "Bottom"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Sku Selector"
-                },
-                "favoriteIcon": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Top right",
-                      "default": "Top right"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Top left",
-                      "default": "Top left"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Favorite Icon"
-                }
-              },
-              "required": [],
-              "title": "Elements Positions"
-            },
-            "hide": {
-              "type": "object",
-              "properties": {
-                "productName": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Product Name"
-                },
-                "productDescription": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Product Description"
-                },
-                "allPrices": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "All Prices"
-                },
-                "installments": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Installments"
-                },
-                "skuSelector": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Sku Selector"
-                },
-                "cta": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Cta"
-                }
-              },
-              "required": [],
-              "title": "Hide"
-            },
-            "onMouseOver": {
-              "type": "object",
-              "properties": {
-                "image": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "Change image",
-                      "default": "Change image"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Zoom image",
-                      "default": "Zoom image"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Image"
-                },
-                "card": {
-                  "anyOf": [
-                    {
-                      "type": "string",
-                      "const": "None",
-                      "default": "None"
-                    },
-                    {
-                      "type": "string",
-                      "const": "Move up",
-                      "default": "Move up"
-                    }
-                  ],
-                  "type": "string",
-                  "title": "Card"
-                },
-                "showFavoriteIcon": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Favorite Icon"
-                },
-                "showSkuSelector": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Sku Selector"
-                },
-                "showCardShadow": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Card Shadow"
-                },
-                "showCta": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "title": "Show Cta"
-                }
-              },
-              "required": [],
-              "title": "On Mouse Over"
-            }
-          },
-          "required": [],
+          "$ref": "#/definitions/ZGVjby1zaXRlcy9mYXNoaW9uL2NvbXBvbmVudHMvcHJvZHVjdC9Qcm9kdWN0Q2FyZC50c3g=@Layout",
           "title": "Card Layout"
         }
       },


### PR DESCRIPTION
## What is this contribution about?

It extends product card props to search result section.

## How to test it?

Open SearchResult section and see its props.

## Extra info

Before VS After
<img width="379" alt="image" src="https://github.com/deco-sites/fashion/assets/1315451/0189012d-b267-4af7-a2e7-8917b765a280"> <img width="362" alt="image" src="https://github.com/deco-sites/fashion/assets/1315451/60ef5c8d-eb3a-4382-a5a2-ba4c807e68ad">

