### PR TITLE
fix: Displacement based on items contianer (ul)

### DIFF
--- a/components/ui/SliderJS.tsx
+++ b/components/ui/SliderJS.tsx
@@ -87,7 +87,7 @@ const setup = ({ rootId, scroll, interval, infinite }: Props) => {
   const goToItem = (index: number) => {
     const item = items.item(index);
 
-    if (!isHTMLElement(item)) {
+    if (!isHTMLElement(item) || !isHTMLElement(slider)) {
       console.warn(
         `Element at index ${index} is not an html element. Skipping carousel`,
       );
@@ -98,7 +98,7 @@ const setup = ({ rootId, scroll, interval, infinite }: Props) => {
     slider.scrollTo({
       top: 0,
       behavior: scroll,
-      left: item.offsetLeft - root.offsetLeft,
+      left: item.offsetLeft - slider.offsetLeft,
     });
   };
 


### PR DESCRIPTION
With this evolution, the calculation of displacement of items in the carousel will be based on the container itself (`slider`). The way it was done before, the container used as the basis for the calculation (`root`) could have incompatible sizes, mainly when the carousel arrows did not contain `position: absolute`.
